### PR TITLE
[Backend] As a user, I can filter search result URL by keyword

### DIFF
--- a/lib/google_crawler/keywords.ex
+++ b/lib/google_crawler/keywords.ex
@@ -61,7 +61,9 @@ defmodule GoogleCrawler.Keywords do
 
   defp keyword_with_result_report do
     Keyword
-    |> join(:left, [keyword], search_results in assoc(keyword, :search_results), as: :search_results)
+    |> join(:left, [keyword], search_results in assoc(keyword, :search_results),
+      as: :search_results
+    )
     |> group_by([keyword], keyword.id)
     |> select_merge([search_results: sr], %{
       result_count: count(sr.id),

--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -4,7 +4,7 @@ defmodule GoogleCrawlerWeb.KeywordController do
   alias GoogleCrawler.Keywords
 
   def index(conn, params) do
-    keywords = Keywords.list_keywords(conn.assigns.user.id, params)
+    keywords = Keywords.list_keywords(conn.assigns.user.id, params["keyword_filter"])
 
     render(conn, "index.html", keywords: keywords)
   end

--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -3,8 +3,8 @@ defmodule GoogleCrawlerWeb.KeywordController do
 
   alias GoogleCrawler.Keywords
 
-  def index(conn, _params) do
-    keywords = Keywords.list_keywords(conn.assigns.user.id)
+  def index(conn, params) do
+    keywords = Keywords.list_keywords(conn.assigns.user.id, params)
 
     render(conn, "index.html", keywords: keywords)
   end

--- a/test/google_crawler/keywords_test.exs
+++ b/test/google_crawler/keywords_test.exs
@@ -47,12 +47,12 @@ defmodule GoogleCrawler.KeywordsTest do
       keyword2 = insert(:keyword, user: user1)
       insert(:keyword, user: user2)
 
-      [list_keyword1, list_keyword2] = Keywords.list_keywords(user1.id, %{})
+      [keyword1_in_db, keyword2_in_db] = Keywords.list_keywords(user1.id, %{})
 
-      assert list_keyword1.id == keyword1.id
-      assert list_keyword1.user_id == user1.id
-      assert list_keyword2.id == keyword2.id
-      assert list_keyword2.user_id == user1.id
+      assert keyword1_in_db.id == keyword1.id
+      assert keyword1_in_db.user_id == user1.id
+      assert keyword2_in_db.id == keyword2.id
+      assert keyword2_in_db.user_id == user1.id
     end
 
     test "lists keyword with result report" do
@@ -62,11 +62,23 @@ defmodule GoogleCrawler.KeywordsTest do
       insert(:ad_search_result, keyword: keyword)
       insert(:top_ad_search_result, keyword: keyword)
 
-      [list_keyword] = Keywords.list_keywords(user.id, %{})
+      [keyword_in_db] = Keywords.list_keywords(user.id, %{})
 
-      assert list_keyword.result_count == 3
-      assert list_keyword.ad_count == 2
-      assert list_keyword.top_ad_count == 1
+      assert keyword_in_db.result_count == 3
+      assert keyword_in_db.ad_count == 2
+      assert keyword_in_db.top_ad_count == 1
+    end
+
+    test "filters keywords which contain matched URL search result if given URL in params" do
+      user = insert(:user)
+      keyword1 = insert(:keyword, user: user)
+      keyword2 = insert(:keyword, user: user)
+      insert(:search_result, url: "example1.com", keyword: keyword1)
+      insert(:search_result, url: "example2.net", keyword: keyword2)
+
+      [keyword1_in_db] = Keywords.list_keywords(user.id, %{"url" => ".com"})
+
+      assert keyword1_in_db.id == keyword1.id
     end
   end
 

--- a/test/google_crawler/keywords_test.exs
+++ b/test/google_crawler/keywords_test.exs
@@ -47,7 +47,7 @@ defmodule GoogleCrawler.KeywordsTest do
       keyword2 = insert(:keyword, user: user1)
       insert(:keyword, user: user2)
 
-      [list_keyword1, list_keyword2] = Keywords.list_keywords(user1.id)
+      [list_keyword1, list_keyword2] = Keywords.list_keywords(user1.id, %{})
 
       assert list_keyword1.id == keyword1.id
       assert list_keyword1.user_id == user1.id
@@ -62,7 +62,7 @@ defmodule GoogleCrawler.KeywordsTest do
       insert(:ad_search_result, keyword: keyword)
       insert(:top_ad_search_result, keyword: keyword)
 
-      [list_keyword] = Keywords.list_keywords(user.id)
+      [list_keyword] = Keywords.list_keywords(user.id, %{})
 
       assert list_keyword.result_count == 3
       assert list_keyword.ad_count == 2

--- a/test/google_crawler_web/controllers/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/keyword_controller_test.exs
@@ -31,7 +31,7 @@ defmodule GoogleCrawlerWeb.KeywordControllerTest do
 
       conn
       |> login_as(user)
-      |> get(Routes.keyword_path(conn, :index), %{"url" => ".com"})
+      |> get(Routes.keyword_path(conn, :index), %{"keyword_filter" => %{"url" => ".com"}})
 
       verify!()
     end

--- a/test/google_crawler_web/controllers/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/keyword_controller_test.exs
@@ -1,6 +1,7 @@
 defmodule GoogleCrawlerWeb.KeywordControllerTest do
   use GoogleCrawlerWeb.ConnCase, async: true
 
+  alias GoogleCrawler.Keywords
   alias GoogleCrawler.Keywords.Keyword
   alias GoogleCrawler.Repo
 
@@ -21,6 +22,18 @@ defmodule GoogleCrawlerWeb.KeywordControllerTest do
       assert html_response(conn, 200) =~ "#{keyword1.title}"
       assert html_response(conn, 200) =~ "#{keyword2.title}"
       refute html_response(conn, 200) =~ "#{other_user_keyword.title}"
+    end
+
+    test "filters the keywords with the given params", %{conn: conn} do
+      %{id: user_id} = user = insert(:user)
+
+      expect(Keywords, :list_keywords, fn ^user_id, %{"url" => ".com"} -> [] end)
+
+      conn
+      |> login_as(user)
+      |> get(Routes.keyword_path(conn, :index), %{"url" => ".com"})
+
+      verify!()
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,5 +2,6 @@ ExUnit.start()
 Faker.start()
 Ecto.Adapters.SQL.Sandbox.mode(GoogleCrawler.Repo, :manual)
 
-Mimic.copy(GoogleCrawler.SearchResults.ParserSupervisor)
+Mimic.copy(GoogleCrawler.Keywords)
 Mimic.copy(GoogleCrawler.Keywords.ScraperSupervisor)
+Mimic.copy(GoogleCrawler.SearchResults.ParserSupervisor)


### PR DESCRIPTION
## What happened

- Update `index` endpoint of KeywordController to accept `url` in params.
- Filter the keywords which contain search result with the given URL.

## Proof Of Work

Visit `/keyword?url=.com`, only keywords with `.com` in URL are displayed.

![GoogleCrawler_·_Phoenix_Framework](https://user-images.githubusercontent.com/14077479/97677076-447eb980-1ac4-11eb-9fd2-3f07fd02e9fe.png)

