### PR TITLE
[API] As a user, I can see a detail of search result

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -52,6 +52,9 @@ config :logger, level: :info
 #
 # Check `Plug.SSL` for all available options in `force_ssl`.
 
+config :jsonapi,
+  host: System.get_env("HOST_URL")
+
 # Finally import the config/prod.secret.exs which loads secrets
 # and configuration from environment variables.
 import_config "prod.secret.exs"

--- a/lib/google_crawler/keywords.ex
+++ b/lib/google_crawler/keywords.ex
@@ -25,10 +25,10 @@ defmodule GoogleCrawler.Keywords do
     |> Repo.all()
   end
 
-  def get_keyword_by_id(id) do
+  def get_keyword_for_user(user_id, id) do
     keyword_with_result_report()
     |> preload([:search_results])
-    |> Repo.get(id)
+    |> Repo.get_by(id: id, user_id: user_id)
   end
 
   def scrape_keyword do

--- a/lib/google_crawler_web.ex
+++ b/lib/google_crawler_web.ex
@@ -24,6 +24,7 @@ defmodule GoogleCrawlerWeb do
       import Plug.Conn
       import GoogleCrawlerWeb.Gettext
       alias GoogleCrawlerWeb.Router.Helpers, as: Routes
+      alias GoogleCrawlerWeb.ErrorHandler
     end
   end
 

--- a/lib/google_crawler_web/api_router.ex
+++ b/lib/google_crawler_web/api_router.ex
@@ -19,7 +19,7 @@ defmodule GoogleCrawlerWeb.ApiRouter do
   scope "/api", GoogleCrawlerWeb.Api do
     pipe_through [:api, :authentication]
 
-    resources "/keyword", KeywordController, only: [:index]
+    resources "/keyword", KeywordController, only: [:index, :show]
   end
 
   scope "/api", GoogleCrawlerWeb.Api do

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -13,7 +13,7 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
   end
 
   def show(conn, %{"id" => keyword_id}) do
-    case Keywords.get_keyword_by_id(keyword_id) do
+    case Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id) do
       nil ->
         ErrorHandler.handle(conn, :not_found)
 

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -11,4 +11,16 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
     |> put_status(:ok)
     |> render("index.json", %{data: keywords, conn: conn})
   end
+
+  def show(conn, %{"id" => keyword_id}) do
+    case Keywords.get_keyword_by_id(keyword_id) do
+      nil ->
+        ErrorHandler.handle(conn, :not_found)
+
+      keyword ->
+        conn
+        |> put_status(:ok)
+        |> render("show.json", %{data: keyword, conn: conn})
+    end
+  end
 end

--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -12,9 +12,15 @@ defmodule GoogleCrawlerWeb.KeywordController do
   def new(conn, _params), do: render(conn, "new.html")
 
   def show(conn, %{"id" => keyword_id}) do
-    keyword = Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id)
+    case Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id) do
+      nil ->
+        conn
+        |> put_flash(:error, "Keyword not found.")
+        |> redirect(to: Routes.keyword_path(conn, :index))
 
-    render(conn, "show.html", keyword: keyword)
+      keyword ->
+        render(conn, "show.html", keyword: keyword)
+    end
   end
 
   def create(conn, keyword_params) do

--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -12,7 +12,7 @@ defmodule GoogleCrawlerWeb.KeywordController do
   def new(conn, _params), do: render(conn, "new.html")
 
   def show(conn, %{"id" => keyword_id}) do
-    keyword = Keywords.get_keyword_by_id(keyword_id)
+    keyword = Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id)
 
     render(conn, "show.html", keyword: keyword)
   end

--- a/lib/google_crawler_web/views/api/keyword_view.ex
+++ b/lib/google_crawler_web/views/api/keyword_view.ex
@@ -2,5 +2,10 @@ defmodule GoogleCrawlerWeb.Api.KeywordView do
   use GoogleCrawlerWeb, :view
 
   def fields, do: [:title, :status]
+
+  def relationships do
+    [search_results: {GoogleCrawlerWeb.Api.SearchResultView, :include}]
+  end
+
   def type, do: "keyword"
 end

--- a/lib/google_crawler_web/views/api/search_result_view.ex
+++ b/lib/google_crawler_web/views/api/search_result_view.ex
@@ -1,6 +1,6 @@
 defmodule GoogleCrawlerWeb.Api.SearchResultView do
   use GoogleCrawlerWeb, :view
 
-  def fields, do: [:url, :title]
+  def fields, do: [:url, :title, :is_ad, :is_top_ad]
   def type, do: "search_result"
 end

--- a/lib/google_crawler_web/views/api/search_result_view.ex
+++ b/lib/google_crawler_web/views/api/search_result_view.ex
@@ -1,0 +1,6 @@
+defmodule GoogleCrawlerWeb.Api.SearchResultView do
+  use GoogleCrawlerWeb, :view
+
+  def fields, do: [:url, :title]
+  def type, do: "search_result"
+end

--- a/test/google_crawler/keywords_test.exs
+++ b/test/google_crawler/keywords_test.exs
@@ -82,15 +82,16 @@ defmodule GoogleCrawler.KeywordsTest do
     end
   end
 
-  describe "get_keyword_by_id/1" do
-    test "returns keyword by the given id" do
-      keyword = insert(:keyword)
+  describe "get_keyword_for_user/1" do
+    test "returns keyword by the given id and user id" do
+      user = insert(:user)
+      keyword = insert(:keyword, user: user)
 
-      result_keyword = Keywords.get_keyword_by_id(keyword.id)
+      result_keyword = Keywords.get_keyword_for_user(user.id, keyword.id)
 
       assert result_keyword.id == keyword.id
       assert result_keyword.title == keyword.title
-      assert result_keyword.user_id == keyword.user_id
+      assert result_keyword.user_id == user.id
     end
 
     test "returns with result report and preloads search_results" do
@@ -100,12 +101,26 @@ defmodule GoogleCrawler.KeywordsTest do
       insert(:ad_search_result, keyword: keyword)
       insert(:top_ad_search_result, keyword: keyword)
 
-      result_keyword = Keywords.get_keyword_by_id(keyword.id)
+      result_keyword = Keywords.get_keyword_for_user(user.id, keyword.id)
 
       assert length(result_keyword.search_results) == 3
       assert result_keyword.result_count == 3
       assert result_keyword.ad_count == 2
       assert result_keyword.top_ad_count == 1
+    end
+
+    test "returns nil if keyword not found" do
+      user = insert(:user)
+
+      assert nil == Keywords.get_keyword_for_user(user.id, "999")
+    end
+
+    test "returns nil if keyword does not belong to the given user" do
+      user1 = insert(:user)
+      user2 = insert(:user)
+      keyword = insert(:keyword, user: user2)
+
+      assert nil == Keywords.get_keyword_for_user(user1.id, keyword.id)
     end
   end
 

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -34,4 +34,78 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
              } = json_response(conn, 200)
     end
   end
+
+  describe "show/2" do
+    test "returns the keyword with search results for the given keyword id", %{conn: conn} do
+      user = insert(:user)
+      %{title: keyword_title, status: keyword_status} = keyword = insert(:keyword, user: user)
+      %{title: search_result1_title} = insert(:search_result, keyword: keyword)
+      %{title: search_result2_title} = insert(:search_result, keyword: keyword)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> get(Routes.keyword_path(conn, :show, keyword.id))
+
+      assert %{
+               "data" => %{
+                 "attributes" => %{
+                   "status" => ^keyword_status,
+                   "title" => ^keyword_title
+                 },
+                 "type" => "keyword",
+                 "relationships" => %{
+                   "search_results" => %{
+                     "data" => [
+                       %{
+                         "type" => "search_result"
+                       },
+                       %{
+                         "type" => "search_result"
+                       }
+                     ]
+                   }
+                 }
+               },
+               "included" => [
+                 %{
+                   "attributes" => %{
+                     "title" => ^search_result1_title
+                   },
+                   "type" => "search_result"
+                 },
+                 %{
+                   "attributes" => %{
+                     "title" => ^search_result2_title
+                   },
+                   "type" => "search_result"
+                 }
+               ]
+             } = json_response(conn, 200)
+    end
+
+    test "returns error if keyword not found", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> get(Routes.keyword_path(conn, :show, "999"))
+
+      assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
+    end
+
+    test "returns error if keyword does not belong to the given user", %{conn: conn} do
+      user = insert(:user)
+      other_user = insert(:user)
+      keyword = insert(:keyword, user: other_user)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> get(Routes.keyword_path(conn, :show, keyword.id))
+
+      assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
+    end
+  end
 end

--- a/test/google_crawler_web/features/keywords/show_keyword_test.exs
+++ b/test/google_crawler_web/features/keywords/show_keyword_test.exs
@@ -1,0 +1,38 @@
+defmodule GoogleCrawlerWeb.ShowKeywordTest do
+  use GoogleCrawlerWeb.FeatureCase, async: true
+
+  @selectors %{
+    keyword_title: "main h1",
+    search_result_table_cell: "main .table-search-result td",
+    notification: ".alert"
+  }
+
+  feature "shows keyword detail with search result", %{session: session} do
+    user = insert(:user)
+    keyword = insert(:keyword, user: user)
+    search_result1 = insert(:search_result, keyword: keyword)
+    search_result2 = insert(:search_result, keyword: keyword)
+
+    session
+    |> login_as(user)
+    |> visit("/keyword/#{keyword.id}")
+    |> assert_has(css(@selectors[:keyword_title], text: keyword.title))
+    |> assert_has(css(@selectors[:search_result_table_cell], text: search_result1.title))
+    |> assert_has(css(@selectors[:search_result_table_cell], text: search_result2.title))
+  end
+
+  feature "redirects to keyword list page with error message if keyword is not found", %{
+    session: session
+  } do
+    user = insert(:user)
+    other_user = insert(:user)
+    keyword = insert(:keyword, user: other_user)
+
+    session
+    |> login_as(user)
+    |> visit("/keyword/#{keyword.id}")
+    |> assert_has(css(@selectors[:notification], text: "Keyword not found."))
+
+    assert "/keyword" == current_path(session)
+  end
+end


### PR DESCRIPTION
## What happened

- Add `GET /api/keyword/:id` to show keyword detail with the search result
- Update show keyword function to get the only keyword that belongs to the given user

## Proof Of Work

- Response from `GET /api/keyword/:id`
<img width="461" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100824383-a1390f80-3488-11eb-97f7-8de4a74633f8.png">

- Search result relationship is included
<img width="529" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100824426-b6ae3980-3488-11eb-861d-4a0e4b50b4dc.png">

- Error message is showed when user visit keyword page with invalid keyword id
![image](https://user-images.githubusercontent.com/14077479/100994444-2ad00680-3589-11eb-85a2-09f645977bf3.png)
