### PR TITLE
[API] As a user, I can add the keyword

### DIFF
--- a/lib/google_crawler_web/api_router.ex
+++ b/lib/google_crawler_web/api_router.ex
@@ -16,10 +16,15 @@ defmodule GoogleCrawlerWeb.ApiRouter do
     plug GoogleCrawlerWeb.Plugs.ApiAuthentication
   end
 
-  scope "/api", GoogleCrawlerWeb.Api do
-    pipe_through [:api, :authentication]
+  pipeline :json_api_deserialize do
+    plug JSONAPI.Deserializer
+    plug JSONAPI.UnderscoreParameters
+  end
 
-    resources "/keyword", KeywordController, only: [:index, :show]
+  scope "/api", GoogleCrawlerWeb.Api do
+    pipe_through [:api, :authentication, :json_api_deserialize]
+
+    resources "/keyword", KeywordController, only: [:index, :show, :create]
   end
 
   scope "/api", GoogleCrawlerWeb.Api do

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -36,8 +36,8 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         |> put_status(:ok)
         |> render("show.json", %{data: keyword, conn: conn})
 
-      {:error, _changeset} ->
-        ErrorHandler.handle(conn, :bad_request)
+      {:error, changeset} ->
+        ErrorHandler.handle(conn, :bad_request, changeset)
     end
   end
 end

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -23,4 +23,21 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         |> render("show.json", %{data: keyword, conn: conn})
     end
   end
+
+  def create(conn, %{"type" => "keyword"} = keyword_params) do
+    keyword_params
+    |> Map.put("user_id", conn.assigns.user.id)
+    |> Keywords.create_keyword()
+    |> case do
+      {:ok, keyword} ->
+        Keywords.scrape_keyword()
+
+        conn
+        |> put_status(:ok)
+        |> render("show.json", %{data: keyword, conn: conn})
+
+      {:error, _changeset} ->
+        ErrorHandler.handle(conn, :bad_request)
+    end
+  end
 end

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -33,11 +33,13 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         Keywords.scrape_keyword()
 
         conn
-        |> put_status(:ok)
+        |> put_status(:created)
         |> render("show.json", %{data: keyword, conn: conn})
 
       {:error, changeset} ->
         ErrorHandler.handle(conn, :bad_request, changeset)
     end
   end
+
+  def create(conn, _), do: ErrorHandler.handle(conn, :bad_request)
 end

--- a/lib/google_crawler_web/error_handler.ex
+++ b/lib/google_crawler_web/error_handler.ex
@@ -1,6 +1,7 @@
 defmodule GoogleCrawlerWeb.ErrorHandler do
   use Phoenix.Controller
 
+  alias Ecto.Changeset
   alias GoogleCrawlerWeb.ErrorView
 
   def handle(conn, status) do
@@ -8,6 +9,14 @@ defmodule GoogleCrawlerWeb.ErrorHandler do
     |> put_status(status)
     |> put_view(ErrorView)
     |> render("error.json", status: status)
+    |> halt()
+  end
+
+  def handle(conn, status, %Changeset{} = changeset) do
+    conn
+    |> put_status(status)
+    |> put_view(ErrorView)
+    |> render("error.json", status: status, changeset: changeset)
     |> halt()
   end
 

--- a/lib/google_crawler_web/views/error_view.ex
+++ b/lib/google_crawler_web/views/error_view.ex
@@ -1,6 +1,8 @@
 defmodule GoogleCrawlerWeb.ErrorView do
   use GoogleCrawlerWeb, :view
 
+  alias Ecto.Changeset
+
   # If you want to customize a particular status code
   # for a certain format, you may uncomment below.
   # def render("500.html", _assigns) do
@@ -14,10 +16,22 @@ defmodule GoogleCrawlerWeb.ErrorView do
     Phoenix.Controller.status_message_from_template(template)
   end
 
+  def render("error.json", %{status: status, changeset: %Changeset{} = changeset}) do
+    %{
+      object: "error",
+      code: status,
+      details: translate_errors(changeset)
+    }
+  end
+
   def render("error.json", %{status: status}) do
     %{
       object: "error",
       code: status
     }
+  end
+
+  defp translate_errors(changeset) do
+    Changeset.traverse_errors(changeset, &translate_error/1)
   end
 end

--- a/test/google_crawler_web/error_handler_test.exs
+++ b/test/google_crawler_web/error_handler_test.exs
@@ -14,6 +14,23 @@ defmodule GoogleCrawlerWeb.ErrorHandlerTest do
     end
   end
 
+  describe "handle/3" do
+    test "renders error view with the given error status code and changeset", %{conn: conn} do
+      changeset = %Ecto.Changeset{
+        errors: [title: {"can't be blank", [validation: :required]}],
+        types: %{title: :string}
+      }
+
+      conn = ErrorHandler.handle(conn, :unauthorized, changeset)
+
+      assert json_response(conn, 401) == %{
+               "object" => "error",
+               "code" => "unauthorized",
+               "details" => %{"title" => ["can't be blank"]}
+             }
+    end
+  end
+
   describe "auth_error/3" do
     test "renders forbidden error view", %{conn: conn} do
       conn = ErrorHandler.auth_error(conn, {:unauthenticated, :unauthenticated}, [])

--- a/test/google_crawler_web/views/error_view_test.exs
+++ b/test/google_crawler_web/views/error_view_test.exs
@@ -15,4 +15,14 @@ defmodule GoogleCrawlerWeb.ErrorViewTest do
     assert %{object: "error", code: :unauthorized} ==
              ErrorView.render("error.json", %{status: :unauthorized})
   end
+
+  test "renders error.json with changeset" do
+    changeset = %Ecto.Changeset{
+      errors: [title: {"can't be blank", [validation: :required]}],
+      types: %{title: :string}
+    }
+
+    assert %{object: "error", code: :bad_request, details: %{title: ["can't be blank"]}} ==
+             ErrorView.render("error.json", %{status: :bad_request, changeset: changeset})
+  end
 end

--- a/test/support/api_conn_case.ex
+++ b/test/support/api_conn_case.ex
@@ -26,7 +26,11 @@ defmodule GoogleCrawlerWeb.ApiConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(GoogleCrawler.Repo, {:shared, self()})
     end
 
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+    conn =
+      Phoenix.ConnTest.build_conn()
+      |> Plug.Conn.put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn}
   end
 
   def login_as(conn, user) do


### PR DESCRIPTION
## What happened

- Setup JSON API deserializer
- Add `POST /api/keyword` which accept JSON API format request body and create a keyword

## Proof Of Work

- Return created keyword after success API call
<img width="476" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100859769-399fb600-34c2-11eb-981e-5c054689f3e9.png">

- Return an error when the request body is invalid
<img width="273" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100860899-af585180-34c3-11eb-9db0-e6ba0d886bf2.png">

