### PR TITLE
[API] As a user, I can delete the keyword

### DIFF
--- a/lib/google_crawler/keywords.ex
+++ b/lib/google_crawler/keywords.ex
@@ -12,9 +12,8 @@ defmodule GoogleCrawler.Keywords do
     |> Repo.insert()
   end
 
-  def delete_keyword(id) do
-    Repo.get!(Keyword, id)
-    |> Repo.delete()
+  def delete_keyword(%Keyword{} = keyword) do
+    Repo.delete(keyword)
   end
 
   def list_keywords(user_id, filter_params) do

--- a/lib/google_crawler_web/api_router.ex
+++ b/lib/google_crawler_web/api_router.ex
@@ -24,7 +24,7 @@ defmodule GoogleCrawlerWeb.ApiRouter do
   scope "/api", GoogleCrawlerWeb.Api do
     pipe_through [:api, :authentication, :json_api_deserialize]
 
-    resources "/keyword", KeywordController, only: [:index, :show, :create]
+    resources "/keyword", KeywordController, only: [:index, :show, :create, :delete]
   end
 
   scope "/api", GoogleCrawlerWeb.Api do

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -1,7 +1,7 @@
 defmodule GoogleCrawlerWeb.Api.KeywordController do
   use GoogleCrawlerWeb, :controller
 
-  alias GoogleCrawler.{Keywords, Repo}
+  alias GoogleCrawler.Keywords
   alias GoogleCrawlerWeb
 
   def index(conn, _params) do
@@ -49,7 +49,8 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         ErrorHandler.handle(conn, :not_found)
 
       keyword ->
-        Repo.delete(keyword)
+        Keywords.delete_keyword(keyword)
+
         send_resp(conn, :no_content, "")
     end
   end

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -1,7 +1,7 @@
 defmodule GoogleCrawlerWeb.Api.KeywordController do
   use GoogleCrawlerWeb, :controller
 
-  alias GoogleCrawler.Keywords
+  alias GoogleCrawler.{Keywords, Repo}
   alias GoogleCrawlerWeb
 
   def index(conn, _params) do
@@ -42,4 +42,15 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
   end
 
   def create(conn, _), do: ErrorHandler.handle(conn, :bad_request)
+
+  def delete(conn, %{"id" => keyword_id}) do
+    case Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id) do
+      nil ->
+        ErrorHandler.handle(conn, :not_found)
+
+      keyword ->
+        Repo.delete(keyword)
+        send_resp(conn, :no_content, "")
+    end
+  end
 end

--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -60,15 +60,17 @@ defmodule GoogleCrawlerWeb.KeywordController do
   end
 
   def delete(conn, %{"id" => keyword_id}) do
-    Keywords.delete_keyword(keyword_id)
-    |> case do
-      {:ok, _} ->
+    case Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id) do
+      nil ->
         conn
-        |> put_flash(:info, "Keyword deleted successfully.")
+        |> put_flash(:error, "Something went wrong, please try again")
         |> redirect(to: Routes.keyword_path(conn, :index))
 
-      {:error, _keyword} ->
+      keyword ->
+        Keywords.delete_keyword(keyword)
+
         conn
+        |> put_flash(:info, "Keyword deleted successfully.")
         |> redirect(to: Routes.keyword_path(conn, :index))
     end
   end

--- a/test/google_crawler/keywords_test.exs
+++ b/test/google_crawler/keywords_test.exs
@@ -29,13 +29,17 @@ defmodule GoogleCrawler.KeywordsTest do
     test "deletes the given keyword" do
       keyword = insert(:keyword)
 
-      {:ok, _} = Keywords.delete_keyword(keyword.id)
+      {:ok, _} = Keywords.delete_keyword(keyword)
 
       assert [] = Repo.all(Keyword)
     end
 
     test "raises errors if the given keyword does not exist" do
-      assert_raise Ecto.NoResultsError, fn -> Keywords.delete_keyword(999) end
+      keyword = insert(:keyword)
+
+      Repo.delete(keyword)
+
+      assert_raise Ecto.StaleEntryError, fn -> Keywords.delete_keyword(keyword) end
     end
   end
 

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -210,4 +210,42 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
       verify!()
     end
   end
+
+  describe "delete/2" do
+    test "deletes user keyword when given valid keyword id", %{conn: conn} do
+      user = insert(:user)
+      keyword = insert(:keyword, user: user)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> delete(Routes.keyword_path(conn, :delete, keyword))
+
+      assert response(conn, 204)
+    end
+
+    test "returns error when given keyword does not belong to user", %{conn: conn} do
+      user = insert(:user)
+      other_user = insert(:user)
+      keyword = insert(:keyword, user: other_user)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> delete(Routes.keyword_path(conn, :delete, keyword))
+
+      assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
+    end
+
+    test "returns error when given keyword does not exist", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> login_as(user)
+        |> delete(Routes.keyword_path(conn, :delete, "999"))
+
+      assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
+    end
+  end
 end


### PR DESCRIPTION
## What happened

Add endpoint `DELETE /api/keyword/:id` to delete given user keyword

## Proof Of Work

- Response with 204 status with empty body when successfully delete keyword
<img width="784" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100959048-0b68b780-3550-11eb-8e60-11c2dba132ee.png">

- Response with 404 error status when user try to delete other user keyword or keyword with given id is not exist
<img width="223" alt="Postman" src="https://user-images.githubusercontent.com/14077479/100959071-14f21f80-3550-11eb-9774-2f35a96abfb3.png">
