### PR TITLE
[API] As a user, I can imports keyword in a CSV file format

### DIFF
--- a/lib/google_crawler_web/api_router.ex
+++ b/lib/google_crawler_web/api_router.ex
@@ -28,6 +28,12 @@ defmodule GoogleCrawlerWeb.ApiRouter do
   end
 
   scope "/api", GoogleCrawlerWeb.Api do
+    pipe_through [:api, :authentication]
+
+    post "/keyword/import", KeywordController, :import, as: :keyword_import
+  end
+
+  scope "/api", GoogleCrawlerWeb.Api do
     pipe_through :api
 
     scope "/auth" do

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -54,4 +54,20 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         send_resp(conn, :no_content, "")
     end
   end
+
+  def import(conn, %{"keywords" => keywords}) do
+    keywords.path
+    |> File.stream!()
+    |> CSV.decode!()
+    |> Enum.each(fn [keyword_title] ->
+      Keywords.create_keyword(%{title: keyword_title, user_id: conn.assigns.user.id})
+      |> case do
+        {:ok, keyword} -> keyword
+      end
+    end)
+
+    Keywords.scrape_keyword()
+
+    send_resp(conn, :no_content, "")
+  end
 end

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -248,4 +248,26 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
       assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
     end
   end
+
+  describe "import/2" do
+    test "creates the keywords from uploaded keywords", %{conn: conn} do
+      user = insert(:user)
+
+      uploaded_keywords = %Plug.Upload{
+        path: "test/support/fixtures/data/keywords.csv",
+        filename: "keywords.csv"
+      }
+
+      GoogleCrawler.Keywords.ScraperSupervisor
+      |> stub(:start_child, fn keyword -> keyword end)
+
+      conn
+      |> login_as(user)
+      |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
+
+      keywords = Keyword |> Repo.all()
+
+      assert length(keywords) == 3
+    end
+  end
 end


### PR DESCRIPTION
## What happened

Add POST `api/keyword/import` endpoint, support keywords uploading in CSV format

## Proof Of Work

Keywords are created after CSV file successfully imported.

![image](https://user-images.githubusercontent.com/14077479/102750979-719b6a00-4399-11eb-8df7-7453772e6123.png)
