### PR TITLE
[API] As a user, I can filter a list of keywords

### DIFF
--- a/lib/google_crawler_web/api_router.ex
+++ b/lib/google_crawler_web/api_router.ex
@@ -28,6 +28,12 @@ defmodule GoogleCrawlerWeb.ApiRouter do
   end
 
   scope "/api", GoogleCrawlerWeb.Api do
+    pipe_through [:api, :authentication]
+
+    post "/keyword/import", KeywordController, :import, as: :keyword_import
+  end
+
+  scope "/api", GoogleCrawlerWeb.Api do
     pipe_through :api
 
     scope "/auth" do

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -54,4 +54,20 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
         send_resp(conn, :no_content, "")
     end
   end
+
+  def import(conn, %{"keywords" => keywords}) do
+    keywords.path
+    |> File.stream!()
+    |> CSV.decode!()
+    |> Enum.each(fn [keyword_title] ->
+      Keywords.create_keyword(%{title: keyword_title, user_id: conn.assigns.user.id})
+      |> case do
+        {:ok, keyword} -> keyword
+      end
+    end)
+
+    Keywords.scrape_keyword()
+
+    send_resp(conn, :no_content, "")
+  end
 end

--- a/lib/google_crawler_web/controllers/api/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/api/keyword_controller.ex
@@ -4,8 +4,8 @@ defmodule GoogleCrawlerWeb.Api.KeywordController do
   alias GoogleCrawler.Keywords
   alias GoogleCrawlerWeb
 
-  def index(conn, _params) do
-    keywords = Keywords.list_keywords(conn.assigns.user.id, %{})
+  def index(conn, params) do
+    keywords = Keywords.list_keywords(conn.assigns.user.id, params["keyword_filter"])
 
     conn
     |> put_status(:ok)

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -248,4 +248,26 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
       assert %{"code" => "not_found", "object" => "error"} = json_response(conn, 404)
     end
   end
+
+  describe "import/2" do
+    test "creates the keywords from uploaded keywords", %{conn: conn} do
+      user = insert(:user)
+
+      uploaded_keywords = %Plug.Upload{
+        path: "test/support/fixtures/data/keywords.csv",
+        filename: "keywords.csv"
+      }
+
+      GoogleCrawler.Keywords.ScraperSupervisor
+      |> stub(:start_child, fn keyword -> keyword end)
+
+      conn
+      |> login_as(user)
+      |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
+
+      keywords = Keyword |> Repo.all()
+
+      assert length(keywords) == 3
+    end
+  end
 end

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -1,8 +1,9 @@
 defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
   use GoogleCrawlerWeb.ApiConnCase, async: true
 
-  alias GoogleCrawler.Repo
+  alias GoogleCrawler.Keywords
   alias GoogleCrawler.Keywords.{Keyword, ScraperSupervisor}
+  alias GoogleCrawler.Repo
 
   describe "index/2" do
     test "returns the keywords for the given user", %{conn: conn} do
@@ -35,6 +36,18 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
                  }
                ]
              } = json_response(conn, 200)
+    end
+
+    test "filters the keywords with the given params", %{conn: conn} do
+      %{id: user_id} = user = insert(:user)
+
+      expect(Keywords, :list_keywords, fn ^user_id, %{"url" => ".com"} -> [] end)
+
+      conn
+      |> login_as(user)
+      |> get(Routes.keyword_path(conn, :index), %{"keyword_filter" => %{"url" => ".com"}})
+
+      verify!()
     end
   end
 


### PR DESCRIPTION
## What happened

Update GET `/api/keywords` to support filter params

## Proof Of Work

Response from `/api/keyword?keyword_filter[title]=a&keyword_filter[url]=.com`, keywords is filtered.
![image](https://user-images.githubusercontent.com/14077479/102751238-ecfd1b80-4399-11eb-9ea1-b65eac01b8f6.png)
