### PR TITLE
As a user, I can see HTML preview page from search_result_html

### DIFF
--- a/lib/google_crawler_web/controllers/keyword_controller.ex
+++ b/lib/google_crawler_web/controllers/keyword_controller.ex
@@ -74,4 +74,18 @@ defmodule GoogleCrawlerWeb.KeywordController do
         |> redirect(to: Routes.keyword_path(conn, :index))
     end
   end
+
+  def result_preview(conn, %{"id" => keyword_id}) do
+    case Keywords.get_keyword_for_user(conn.assigns.user.id, keyword_id) do
+      nil ->
+        conn
+        |> put_flash(:error, "Keyword not found.")
+        |> redirect(to: Routes.keyword_path(conn, :index))
+
+      keyword ->
+        conn
+        |> put_layout(false)
+        |> render("result_preview.html", result_page_html: keyword.result_page_html)
+    end
+  end
 end

--- a/lib/google_crawler_web/router.ex
+++ b/lib/google_crawler_web/router.ex
@@ -28,6 +28,7 @@ defmodule GoogleCrawlerWeb.Router do
     pipe_through :authentication
 
     resources "/keyword", KeywordController, only: [:index, :show, :new, :create, :delete]
+    get "/keyword/:id/result_preview", KeywordController, :result_preview
     post "/keyword/import", KeywordController, :import, as: :keyword_import
   end
 

--- a/lib/google_crawler_web/templates/keyword/result_preview.html.eex
+++ b/lib/google_crawler_web/templates/keyword/result_preview.html.eex
@@ -1,0 +1,1 @@
+<%= raw(@result_page_html) %>

--- a/lib/google_crawler_web/templates/keyword/show.html.eex
+++ b/lib/google_crawler_web/templates/keyword/show.html.eex
@@ -39,18 +39,14 @@
       <%= if @keyword.result_page_html == nil do %>
         <button class="btn btn-secondary" role="button">Searching</button>
       <% else %>
-        <a class="btn btn-primary" data-toggle="collapse" href="#searchResult" role="button" aria-expanded="false">Search Result</a>
+        <a class="btn btn-primary" data-toggle="collapse" href="#searchResult" role="button" aria-expanded="false">Search Result HTML</a>
+        <a class="btn btn-info" href=<%= Routes.keyword_path(@conn, :result_preview, @keyword) %> target="_blank" ><i class="fas fa-glasses"></i>  Search Result Preview</a>
       <% end %>
     </p>
   </div>
 </div>
 <div class="row">
   <div class="col">
-    <div class="collapse" id="searchResult">
-      <div class="card card-body">
-        <%= @keyword.result_page_html %>
-      </div>
-    </div>
     <div class="collapse" id="searchResult">
       <div class="card card-body">
         <%= @keyword.result_page_html %>

--- a/test/google_crawler_web/features/keywords/preview_result_page_test.exs
+++ b/test/google_crawler_web/features/keywords/preview_result_page_test.exs
@@ -1,0 +1,21 @@
+defmodule GoogleCrawlerWeb.PreviewResultPageTest do
+  use GoogleCrawlerWeb.FeatureCase, async: true
+
+  @selectors %{
+    title: "h1",
+    result_item: "p"
+  }
+
+  feature "renders page from the HTML result page", %{session: session} do
+    user = insert(:user)
+
+    keyword =
+      insert(:keyword, user: user, result_page_html: "<h1>Search result</h1><p>Result1</p>")
+
+    session
+    |> login_as(user)
+    |> visit("/keyword/#{keyword.id}/result_preview")
+    |> assert_has(css(@selectors[:title], text: "Search result"))
+    |> assert_has(css(@selectors[:result_item], text: "Result1"))
+  end
+end


### PR DESCRIPTION
## What happened

Add HTML preview page, render from `search_result_html` of the keyword

## Proof Of Work

Result page is rendered

![2563-12-23 16 56 56](https://user-images.githubusercontent.com/14077479/102984254-eb6d5800-453f-11eb-8967-9077198a5164.gif)

