### PR TITLE
Validate CSV format when user importing keywords

### DIFF
--- a/lib/google_crawler/keywords/keyword_import_error.ex
+++ b/lib/google_crawler/keywords/keyword_import_error.ex
@@ -1,0 +1,3 @@
+defmodule GoogleCrawler.Keywords.KeywordImportError do
+  defexception message: "Failed to import keywords."
+end

--- a/lib/google_crawler/keywords/keyword_importer.ex
+++ b/lib/google_crawler/keywords/keyword_importer.ex
@@ -1,6 +1,5 @@
 defmodule GoogleCrawler.Keywords.KeywordImporter do
   @file_content_type "text/csv"
-  @keyword_separator ?,
 
   alias GoogleCrawler.{Keywords, Repo}
   alias GoogleCrawler.Keywords.KeywordImportError
@@ -16,7 +15,7 @@ defmodule GoogleCrawler.Keywords.KeywordImporter do
   defp decode_csv(keyword_path) do
     keyword_path
     |> File.stream!()
-    |> CSV.decode(separator: @keyword_separator)
+    |> CSV.decode()
   end
 
   defp do_import(csv_stream, user_id) do

--- a/lib/google_crawler/keywords/keyword_importer.ex
+++ b/lib/google_crawler/keywords/keyword_importer.ex
@@ -1,0 +1,44 @@
+defmodule GoogleCrawler.Keywords.KeywordImporter do
+  @file_content_type "text/csv"
+  @keyword_separator ?,
+
+  alias GoogleCrawler.{Keywords, Repo}
+  alias GoogleCrawler.Keywords.KeywordImportError
+
+  def import(%{content_type: @file_content_type, path: keyword_path}, user_id) do
+    csv_stream = decode_csv(keyword_path)
+
+    Repo.transaction(fn -> do_import(csv_stream, user_id) end)
+  end
+
+  def import(_, _), do: {:error, "Invalid file type."}
+
+  defp decode_csv(keyword_path) do
+    keyword_path
+    |> File.stream!()
+    |> CSV.decode(separator: @keyword_separator)
+  end
+
+  defp do_import(csv_stream, user_id) do
+    try do
+      Enum.each(csv_stream, fn stream_row ->
+        case stream_row do
+          {:ok, keywords} ->
+            Enum.each(keywords, fn keyword -> create_keyword(keyword, user_id) end)
+
+          {:error, _} ->
+            raise KeywordImportError
+        end
+      end)
+    rescue
+      e in KeywordImportError -> Repo.rollback(e.message)
+    end
+  end
+
+  defp create_keyword(title, user_id) do
+    case Keywords.create_keyword(%{title: title, user_id: user_id}) do
+      {:ok, _} -> :ok
+      {:error, _} -> raise KeywordImportError
+    end
+  end
+end

--- a/test/google_crawler/keywords/keyword_importer_test.exs
+++ b/test/google_crawler/keywords/keyword_importer_test.exs
@@ -1,0 +1,50 @@
+defmodule GoogleCrawler.Keywords.KeywordImporterTest do
+  use GoogleCrawler.DataCase, async: true
+
+  alias GoogleCrawler.Keywords.{Keyword, KeywordImporter}
+
+  describe "import/2" do
+    test "creates keyword from given CSV file" do
+      user = insert(:user)
+
+      assert {:ok, _} =
+               KeywordImporter.import(
+                 %{content_type: "text/csv", path: "test/support/fixtures/data/keywords.csv"},
+                 user.id
+               )
+
+      [keyword1_in_db, keyword2_in_db, keyword3_in_db] = Repo.all(Keyword)
+
+      assert keyword1_in_db.title == "apple"
+      assert keyword1_in_db.user_id == user.id
+      assert keyword2_in_db.title == "orange"
+      assert keyword2_in_db.user_id == user.id
+      assert keyword3_in_db.title == "pineapple"
+      assert keyword3_in_db.user_id == user.id
+    end
+
+    test "returns error and does not create keyword if given invalid CSV file format" do
+      user = insert(:user)
+
+      assert {:error, "Failed to import keywords."} =
+               KeywordImporter.import(
+                 %{
+                   content_type: "text/csv",
+                   path: "test/support/fixtures/data/invalid_keywords.csv"
+                 },
+                 user.id
+               )
+
+      assert Repo.all(Keyword) == []
+    end
+
+    test "returns error and does not create keyword if given invalid file type" do
+      user = insert(:user)
+
+      assert {:error, "Invalid file type."} =
+               KeywordImporter.import(%{content_type: "application/pdf"}, user.id)
+
+      assert Repo.all(Keyword) == []
+    end
+  end
+end

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -296,10 +296,10 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
         |> login_as(user)
         |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_file})
 
-      assert %{
+      assert json_response(conn, 400) == %{
                "code" => "bad_request",
                "object" => "error"
-             } = json_response(conn, 400)
+             }
 
       assert Repo.all(Keyword) == []
 
@@ -322,10 +322,10 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
         |> login_as(user)
         |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
 
-      assert %{
+      assert json_response(conn, 400) == %{
                "code" => "bad_request",
                "object" => "error"
-             } = json_response(conn, 400)
+             }
 
       assert Repo.all(Keyword) == []
 

--- a/test/google_crawler_web/controllers/api/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/api/keyword_controller_test.exs
@@ -268,6 +268,7 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
 
       uploaded_keywords = %Plug.Upload{
         path: "test/support/fixtures/data/keywords.csv",
+        content_type: "text/csv",
         filename: "keywords.csv"
       }
 
@@ -281,6 +282,54 @@ defmodule GoogleCrawlerWeb.Api.KeywordControllerTest do
       keywords = Keyword |> Repo.all()
 
       assert length(keywords) == 3
+    end
+
+    test "returns error when imports invalid file type", %{conn: conn} do
+      user = insert(:user)
+
+      reject(GoogleCrawler.Keywords.ScraperSupervisor, :start_child, 1)
+
+      uploaded_file = %Plug.Upload{content_type: "application/pdf"}
+
+      conn =
+        conn
+        |> login_as(user)
+        |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_file})
+
+      assert %{
+               "code" => "bad_request",
+               "object" => "error"
+             } = json_response(conn, 400)
+
+      assert Repo.all(Keyword) == []
+
+      verify!()
+    end
+
+    test "returns error when imported CSV file is invalid", %{conn: conn} do
+      user = insert(:user)
+
+      reject(GoogleCrawler.Keywords.ScraperSupervisor, :start_child, 1)
+
+      uploaded_keywords = %Plug.Upload{
+        path: "test/support/fixtures/data/invalid_keywords.csv",
+        content_type: "text/csv",
+        filename: "invalid_keywords.csv"
+      }
+
+      conn =
+        conn
+        |> login_as(user)
+        |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
+
+      assert %{
+               "code" => "bad_request",
+               "object" => "error"
+             } = json_response(conn, 400)
+
+      assert Repo.all(Keyword) == []
+
+      verify!()
     end
   end
 end

--- a/test/google_crawler_web/controllers/keyword_controller_test.exs
+++ b/test/google_crawler_web/controllers/keyword_controller_test.exs
@@ -105,6 +105,7 @@ defmodule GoogleCrawlerWeb.KeywordControllerTest do
 
       uploaded_keywords = %Plug.Upload{
         path: "test/support/fixtures/data/keywords.csv",
+        content_type: "text/csv",
         filename: "keywords.csv"
       }
 
@@ -115,9 +116,57 @@ defmodule GoogleCrawlerWeb.KeywordControllerTest do
       |> login_as(user)
       |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
 
-      keywords = Keyword |> Repo.all()
+      keywords = Repo.all(Keyword)
 
       assert length(keywords) == 3
+    end
+
+    test "redirects to new keyword page with error message when imports invalid file type", %{
+      conn: conn
+    } do
+      user = insert(:user)
+
+      reject(GoogleCrawler.Keywords.ScraperSupervisor, :start_child, 1)
+
+      uploaded_file = %Plug.Upload{content_type: "application/pdf"}
+
+      conn =
+        conn
+        |> login_as(user)
+        |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_file})
+
+      assert redirected_to(conn, 302) === Routes.keyword_path(conn, :new)
+      assert get_flash(conn, :error) === "Invalid file type."
+
+      assert Repo.all(Keyword) == []
+
+      verify!()
+    end
+
+    test "redirects to new keyword page with error message when imported CSV file is invalid", %{
+      conn: conn
+    } do
+      user = insert(:user)
+
+      reject(GoogleCrawler.Keywords.ScraperSupervisor, :start_child, 1)
+
+      uploaded_keywords = %Plug.Upload{
+        path: "test/support/fixtures/data/invalid_keywords.csv",
+        content_type: "text/csv",
+        filename: "invalid_keywords.csv"
+      }
+
+      conn =
+        conn
+        |> login_as(user)
+        |> post(Routes.keyword_import_path(conn, :import), %{keywords: uploaded_keywords})
+
+      assert redirected_to(conn, 302) === Routes.keyword_path(conn, :new)
+      assert get_flash(conn, :error) === "Failed to import keywords."
+
+      assert Repo.all(Keyword) == []
+
+      verify!()
     end
   end
 

--- a/test/support/fixtures/data/invalid_keywords.csv
+++ b/test/support/fixtures/data/invalid_keywords.csv
@@ -1,0 +1,3 @@
+apple
+orange
+pineapple,""


### PR DESCRIPTION
## What happened

- Refactor keyword importer module
- Show error message when a user tries to import invalid CSV file or invalid file type
- Support CSV file in one line format

## Proof Of Work

- Display error when file is an invalid type.

![image](https://user-images.githubusercontent.com/14077479/103273823-d175be80-49f2-11eb-93a3-8450fd5e8bd6.png)

- Display error when CSV file is invalid format

![image](https://user-images.githubusercontent.com/14077479/103273874-e81c1580-49f2-11eb-9346-9f89c542ec59.png)

- Import with one line CSV file

![image](https://user-images.githubusercontent.com/14077479/103274045-45b06200-49f3-11eb-9e67-0ddbf667beb1.png)

- Keywords are created

![image](https://user-images.githubusercontent.com/14077479/103273988-2ca7b100-49f3-11eb-8c5d-87edda1fb832.png)
